### PR TITLE
Updated SmsChannel.php - routeNotificationForSms Support

### DIFF
--- a/src/Channels/SmsChannel.php
+++ b/src/Channels/SmsChannel.php
@@ -15,6 +15,10 @@ class SmsChannel
          */
         $message = $notification->toSms($notifiable);
 
+        if (empty($message->getRecipients()) && method_exists($notifiable, 'routeNotificationForSms')) {
+            $message->to($notifiable->routeNotificationForSms($notification));
+        }
+        
         $this->validate($message);
         $manager = app()->make('tzsk-sms');
 


### PR DESCRIPTION
Hello,

I like the idea of driving the `->to()` from the Notifiable, like how Laravel does it with their default Mail and Vonage installations.

https://laravel.com/docs/10.x/notifications#routing-sms-notifications
https://laravel.com/docs/10.x/notifications#customizing-the-recipient

```php
    public function routeNotificationForMail(Notification $notification): array|string
    {
        return $this->email_address;
    }

    public function routeNotificationForVonage(Notification $notification): string
    {
        return $this->phone_number;
    }
```

To that end, I've added the ability to do the same with this PR, which adds support for a function like this on any Notifiable:

```php
    public function routeNotificationForSms(Notification $notification): array|string
    {
        return $this->phone_number;
    }
```

I hope you agree and that is a useful feature for everyone. This could potentially eliminate the need to do `->to()` in every Notification. If you do specify a `->to()`, then this is skipped as expected.

I didn't modify the README or CHANGELOG, nor did I run unit tests. Apologies for the extra work on that end :)

Cheers!

- Nick