### PR TITLE
added SMSApi driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ List of supported gateways:
 -   [Rahyabir](https://sms.rahyab.ir/)
 -   [D7networks](https://d7networks.com/)
 -   [Hamyarsms](https://hamyarsms.com/)
+-   [SMSApi](https://www.smsapi.si/)
 
 -   Others are under way.
 

--- a/config/sms.php
+++ b/config/sms.php
@@ -156,6 +156,13 @@ return [
             'from' => 'Your Default From Number',
             'flash' => false,
         ],
+        'smsapi' => [
+            'url' => 'http://www.smsapi.si/poslji-sms',
+            'username' => 'Your SMSApi Username',
+            'password' => 'Your SMSApi Password',
+            'from' => 'Your Default From Number',
+            'cc' => 'Your Default Country Code'
+        ],
     ],
 
     /*
@@ -192,5 +199,6 @@ return [
         'rahyabir' => \Tzsk\Sms\Drivers\Rahyabir::class,
         'd7networks' => \Tzsk\Sms\Drivers\D7networks::class,
         'hamyarsms' => \Tzsk\Sms\Drivers\Hamyarsms::class,
+        'smsapi' => \Tzsk\Sms\Drivers\SmsApi::class,
     ],
 ];

--- a/src/Drivers/SmsApi.php
+++ b/src/Drivers/SmsApi.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tzsk\Sms\Drivers;
+
+use GuzzleHttp\Client;
+use Tzsk\Sms\Contracts\Driver;
+
+class SmsApi extends Driver
+{
+    protected Client $client;
+
+    private array $options = [];
+    
+    protected function boot(): void
+    {
+        $this->client = new Client();
+        $this->options['from'] = $this->settings['from'];
+    }
+
+    /**
+     * Provides a way to pass additional valid parameters or override existing ones
+     *
+     * @param array $options
+     * @return self
+     */
+    public function with(array $options): self
+    {
+        if (!empty(array_diff(array_keys($options), ['from', 'sname', 'cc', 'sid', 'ur', 'dr', 'stime', 'unicode', 'mms', 'mmstype', 'mmsurl']))) {
+            throw new \Exception(__METHOD__  . " contains invalid options");
+        }
+
+        foreach($options as $option => $value) {
+            $this->options[$option] = $value;
+        }
+
+        return $this;
+    }
+
+    public function send()
+    {
+        /** @var \Illuminate\Support\Collection $response */
+        $response = collect();
+        foreach ($this->recipients as $recipient) {
+            $response->put(
+                $recipient,
+                $this->client->post(
+                    data_get($this->settings, 'url'),
+                    [
+                        'form_params' => $this->payload($recipient),
+                        'verify' => false
+                    ]
+                )
+            );
+        }
+        return (count($this->recipients) == 1) ? $response->first() : $response;
+    }
+
+    public function payload($recipient): array
+    {
+        $payload = [
+            'un' => data_get($this->settings, 'username'),
+            'ps' => data_get($this->settings, 'password'),
+            'from' => $this->options['from'],
+            'to' => $recipient,
+            'cc' => data_get($this->settings, 'cc'),
+            'm' => $this->body,
+        ];
+
+        return  array_merge($payload, $this->options);
+    }
+}

--- a/tests/Drivers/SmsApiTest.php
+++ b/tests/Drivers/SmsApiTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tzsk\Sms\Tests\Drivers;
+
+use Tzsk\Sms\Facades\Sms;
+use Tzsk\Sms\Tests\TestCase;
+use Tzsk\Sms\Tests\Mocks\Drivers\MockSmsApi;
+
+class SmsApiTest extends TestCase
+{
+    use DriverCommon;
+
+    protected function getDriver()
+    {
+        return new MockSmsApi();
+    }
+
+    public function test_it_wont_accept_invalid_parameters()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Tzsk\Sms\Drivers\SmsApi::with contains invalid options');
+        Sms::via('smsapi')->send("this message", function ($sms) {
+            $sms->to(['Number 1', 'Number 2'])->with(['invalid_parameter' => 'value', 'sid' => 1, 'sname' => 'Sender Name']);
+        });
+    }
+}

--- a/tests/Mocks/Drivers/MockSmsApi.php
+++ b/tests/Mocks/Drivers/MockSmsApi.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tzsk\Sms\Tests\Mocks\Drivers;
+
+use Tzsk\Sms\Drivers\SmsApi;
+
+class MockSmsApi extends SmsApi
+{
+    use MockCommon;
+
+    public function __construct(array $settings = [])
+    {
+        parent::__construct(config('sms.drivers.smsapi'));
+    }
+}


### PR DESCRIPTION
Driver contains an additional method Tzsk\Sms\Drivers\SmsApi::with to pass in additional parameters or override existing ones.
On what place in the README.md should I document this functionality?