### PR TITLE
fix 'Invalid variable name' when we use space in pattern with trim

### DIFF
--- a/src/Drivers/Farazsmspattern.php
+++ b/src/Drivers/Farazsmspattern.php
@@ -36,7 +36,7 @@ class Farazsmspattern extends Driver
                 continue;
             }
             $key_value = explode('=', $datum);
-            $input_data[$key_value[0]] = $key_value[1];
+            $input_data[trim($key_value[0])] = $key_value[1];
         }
 
         return [


### PR DESCRIPTION
when we use 
```
sms()->via('farazsmspattern')->send("patterncode=123 \n verification-code=$code \n arg2=family")->to(['Number 1', 'Number 2'])->dispatch();
```
occure following error because we use space 
'Invalid variable name'