### PR TITLE
Add config() method for runtime SMS gateway configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ sms()->via('melipayamakpattern')->send("patterncode=123 \n arg1=name \n arg2=fam
 
 ```
 
+### Runtime Configuration
+
+You can override the default gateway configuration at runtime:
+
+```php
+# Override configuration for this specific SMS
+Sms::via('gateway')
+    ->config(['from' => 'CUSTOM-SENDER'])
+    ->send('this message')
+    ->to(['Number1', 'Number2'])
+    ->dispatch();
+```
+
 ## :heart_eyes: Channel Usage
 
 First you have to create your notification using `php artisan make:notification` command. then `SmsChannel::class` can

--- a/src/Sms.php
+++ b/src/Sms.php
@@ -40,6 +40,19 @@ class Sms
         return $this;
     }
 
+    /**
+     * Override configuration at runtime.
+     *
+     * @param  array  $overrides  Configuration parameters to override
+     * @return $this
+     */
+    public function config(array $overrides): self
+    {
+        $this->settings = array_merge($this->settings, $overrides);
+
+        return $this;
+    }
+
     public function send($message, $callback = null)
     {
         if ($message instanceof Builder) {


### PR DESCRIPTION
## Description
This PR adds a new `config()` method to the Sms class that allows overriding gateway configurations at runtime without modifying the global configuration.

Fixes #1739

## Use case
Many applications need to dynamically adjust SMS gateway settings based on specific conditions:

- Multi-tenant applications needing different sender IDs per tenant
- Applications sending messages with different priorities or categories
- Situations where the sender ID needs to change based on message content
- Testing scenarios that need to modify gateway behavior

## Example usage
```php
// Override credentials
Sms::via('gateway')
    ->config(['apiKey' => 'xxxxxxxx'])
    ->send("this message")
    ->to(['Number 1', 'Number 2'])
    ->dispatch();


// Override multiple settings
Sms::via('kavenegar')
    ->config([
        'from' => '099999',
        'flash' => true
    ])
    ->send('Emergency alert')
    ->to(['1234567890', '0987654321'])
    ->dispatch();